### PR TITLE
feat/validate-otp-code-expired-and-attempts

### DIFF
--- a/src/common/constants/errorMessages.ts
+++ b/src/common/constants/errorMessages.ts
@@ -12,6 +12,10 @@ export const ErrorMessages = {
     OTP_EXPIRED: () => 'OTP expirado',
     OTP_USED: () => 'OTP já foi utilizado',
     INVALID_OTP_CODE: () => 'Código OTP inválido',
+    MAX_ATTEMPTS_EXCEEDED: () =>
+      'Número máximo de tentativas excedido. OTP bloqueado.',
+    OTP_ALREADY_ACTIVE: () =>
+      'Já existe um OTP ativo, expirado ou bloqueado. Aguarde o tempo de expiração.',
   },
   CUSTOMER: {
     NOT_FOUND_DOCUMENT: (document: string) =>

--- a/src/common/service/env/env.ts
+++ b/src/common/service/env/env.ts
@@ -27,6 +27,7 @@ export const envSchema = z
     SERVER_URL: z.string(),
     OTP_MINUTE_DURATION: z.coerce.number().min(1).max(10).optional().default(5),
     OTP_LENGTH: z.coerce.number().min(2).max(10).optional().default(6),
+    OTP_MAX_ATTEMPTS: z.coerce.number().min(1).max(10).optional().default(3),
     JWT_OTP_SECRET: z.string(),
   })
   .transform((env) => ({

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -64,12 +64,10 @@ export class AuthService {
   async login(email: string, password: string): Promise<LoginOtpResponseDto> {
     const user = await this.validateUser(email, password)
 
-    await this.userOtpHistoryService.expireOldOtps(user.id)
-
-    await this.cache.invalidateCache(`otp_session:${user.id}:*`)
-
     const { hash, expiresAt, otpCode } =
       await this.userOtpHistoryService.create(user.id)
+
+    await this.cache.invalidateCache(`otp_session:${user.id}:*`)
 
     const ttlSeconds = Math.floor((expiresAt.getTime() - Date.now()) / 1000)
 

--- a/src/modules/user-otp-history/repositories/port/user-otp-history.repository.port.ts
+++ b/src/modules/user-otp-history/repositories/port/user-otp-history.repository.port.ts
@@ -17,5 +17,7 @@ export abstract class UserOtpHistoryRepositoryPort {
     userId: number,
   ): Promise<UserOtpHistoryDto | null>
 
+  abstract findByUserId(userId: number): Promise<UserOtpHistoryDto | null>
+
   abstract expireOldOtps(userId: number): Promise<void>
 }

--- a/src/modules/user-otp-history/repositories/user-otp-history.repository.ts
+++ b/src/modules/user-otp-history/repositories/user-otp-history.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
-import { Repository } from 'typeorm'
+import { Not, Repository } from 'typeorm'
 import { UserOtpHistoryRepositoryPort } from './port/user-otp-history.repository.port'
 import { UserOtpHistory } from '../entities/user-otp-history.entity'
 import { CreateUserOtpHistoryDto } from '../dto/create-user-otp-history.dto'
@@ -60,9 +60,19 @@ export class UserOtpHistoryRepository extends UserOtpHistoryRepositoryPort {
     })
   }
 
+  async findByUserId(userId: number): Promise<UserOtpHistoryDto | null> {
+    return this.repository.findOne({
+      where: { userId, status: Not(UserOTPHistoryStatus.VALIDATED) },
+      order: { expiresAt: 'DESC' },
+    })
+  }
+
   async expireOldOtps(userId: number): Promise<void> {
     await this.repository.update(
-      { userId, status: UserOTPHistoryStatus.PENDING },
+      {
+        userId,
+        status: UserOTPHistoryStatus.PENDING,
+      },
       { status: UserOTPHistoryStatus.EXPIRED },
     )
   }


### PR DESCRIPTION
Foi realizado a correção e implementação da validação do token OTP para quando o usuário passar as tentativas bloquear o acesso ao OTP gerado e expirar a sessão caso uma esteja ativa do usuário e ele realizar o login novamente assim expirando a antiga.